### PR TITLE
switch DMatrix32 and DMatrix64 from object to ref object

### DIFF
--- a/private/access.nim
+++ b/private/access.nim
@@ -172,16 +172,10 @@ proc clone*[M, N: static[int]](m: Matrix64[M, N]): Matrix64[M, N] =
   copyMem(result.fp, m.fp, M * N * sizeof(float64))
 
 proc clone*(m: DMatrix32): DMatrix32 =
-  result.order = m.order
-  result.M = m.M
-  result.N = m.N
-  result.data = m.data
+  result = DMatrix32(data:m.data, order:m.order, M:m.M, N:m.N)
 
 proc clone*(m: DMatrix64): DMatrix64 =
-  result.order = m.order
-  result.M = m.M
-  result.N = m.N
-  result.data = m.data
+  result = DMatrix64(data:m.data, order:m.order, M:m.M, N:m.N)
 
 proc map*[M, N: static[int]](m: Matrix32[M, N], f: proc(x: float32): float32): Matrix32[M, N] =
   result.order = m.order
@@ -196,17 +190,11 @@ proc map*[M, N: static[int]](m: Matrix64[M, N], f: proc(x: float64): float64): M
     result.data[i] = f(m.data[i])
 
 proc map*(m: DMatrix32, f: proc(x: float32): float32): DMatrix32 =
-  result.order = m.order
-  result.M = m.M
-  result.N = m.N
-  result.data = newSeq[float32](m.M * m.N)
+  result = DMatrix32(data:newSeq[float32](m.M * m.N), order:m.order, M:m.M, N:m.N)
   for i in 0 .. < (m.M * m.N):
     result.data[i] = f(m.data[i])
 
 proc map*(m: DMatrix64, f: proc(x: float64): float64): DMatrix64 =
-  result.order = m.order
-  result.M = m.M
-  result.N = m.N
-  result.data = newSeq[float64](m.M * m.N)
+  result = DMatrix64(data:newSeq[float64](m.M * m.N), order:m.order, M:m.M, N:m.N)
   for i in 0 .. < (m.M * m.N):
     result.data[i] = f(m.data[i])

--- a/private/initialize.nim
+++ b/private/initialize.nim
@@ -114,6 +114,7 @@ template makeSMatrixPrivate(M, N, f, order, result: expr) =
   makeMatrixPrivate(M, N, f, order, result)
 
 template makeDMatrixPrivate(M, N, f, order, result: expr, A: typedesc) =
+  new result
   result.data = newSeq[A](M * N)
   result.M = M
   result.N = N
@@ -152,6 +153,7 @@ template constantSMatrixPrivate(M, N, x, order, result: expr) =
     result.data[i] = x
 
 template constantDMatrixPrivate(M, N, x, order, result: expr, A: typedesc) =
+  new result
   result.data = newSeq[A](M * N)
   result.order = order
   result.M = M

--- a/private/ops.nim
+++ b/private/ops.nim
@@ -15,6 +15,7 @@
 template len(m: DMatrix32 or DMatrix64): int = m.M * m.N
 
 template initLike(r, m: typed) =
+  new r
   when m is DMatrix32:
     r.data = newSeq[float32](m.len)
   when m is DMatrix64:
@@ -421,6 +422,7 @@ template matrixMult(M, N, K, a, b, result: expr): auto =
     gemm(colMajor, transpose, noTranspose, M, N, K, 1, a.fp, K, b.fp, K, 0, result.fp, M)
 
 template matrixMultD(a, b, result: expr): auto =
+  new result
   let
     M = a.M
     K = a.N

--- a/private/trivial_ops.nim
+++ b/private/trivial_ops.nim
@@ -17,6 +17,7 @@ template transposeS(a, result: expr) =
   result.data = a.data
 
 template transposeD(a, result: expr) =
+  new result
   result.M = a.N
   result.N = a.M
   result.order = if a.order == rowMajor: colMajor else: rowMajor
@@ -39,6 +40,7 @@ template reshapeS(M, N, A, B, m , result: expr) =
 
 template reshapeD(A, B, m , result: expr) =
   assert(m.M * m.N == A * B, "The dimensions do not match: M = " & $(m.M) & ", N = " & $(m.N) & ", A = " & $(A) & ", B = " & $(B))
+  new result
   result.M = A
   result.N = B
   result.order = m.order
@@ -61,6 +63,7 @@ template asMatrixS(N, A, B, v, order, result: expr) =
 
 template asMatrixD(A, B, v, order, result: expr) =
   assert(v.len == A * B, "The dimensions do not match: N = " & $(v.len) & ", A = " & $(A) & ", B = " & $(B))
+  new result
   result.order = order
   shallowCopy(result.data, v)
   result.M = A

--- a/private/types.nim
+++ b/private/types.nim
@@ -23,11 +23,11 @@ type
     data: ref array[M * N, float64]
   DVector32* = seq[float32]
   DVector64* = seq[float64]
-  DMatrix32* = object
+  DMatrix32* = ref object
     order: OrderType
     M, N: int
     data: seq[float32]
-  DMatrix64* = object
+  DMatrix64* = ref object
     order: OrderType
     M, N: int
     data: seq[float64]
@@ -112,31 +112,21 @@ proc to64*[M, N: static[int]](m: Matrix32[M, N]): Matrix64[M, N] =
   for i in 0 .. < (M * N):
     result.data[i] = m.data[i].float64
 
-proc to32*(v: DMatrix64): DMatrix32 =
-  result.order = v.order
-  result.M = v.M
-  result.N = v.N
-  result.data = v.data.mapIt(float32, it.float32)
+proc to32*(m: DMatrix64): DMatrix32 =
+  result = DMatrix32(data:m.data.mapIt(float32, it.float32), order:m.order, M:m.M, N:m.N)
 
-proc to64*(v: DMatrix32): DMatrix64 =
-  result.order = v.order
-  result.M = v.M
-  result.N = v.N
-  result.data = v.data.mapIt(float64, it.float64)
+proc to64*(m: DMatrix32): DMatrix64 =
+  result = DMatrix64(data:m.data.mapIt(float64, it.float64), order:m.order, M:m.M, N:m.N)
 
 proc toDynamic*[N: static[int]](v: Vector32[N] or Vector64[N]): auto = @(v[])
 
 proc toDynamic*[M, N: static[int]](m: Matrix32[M, N]): DMatrix32 =
-  result.data = @(m.data[])
-  result.order = m.order
-  result.M = M
-  result.N = N
+  let data = @(m.data[])
+  result = DMatrix32(data:data, order:m.order, M:m.M, N:m.N)
 
 proc toDynamic*[M, N: static[int]](m: Matrix64[M, N]): DMatrix64 =
-  result.data = @(m.data[])
-  result.order = m.order
-  result.M = M
-  result.N = N
+  let data = @(m.data[])
+  result = DMatrix64(data:data, order:m.order, M:m.M, N:m.N)
 
 proc toStatic*(v: DVector32, N: static[int]): Vector32[N] =
   new result

--- a/private/ufunc.nim
+++ b/private/ufunc.nim
@@ -34,10 +34,7 @@ template makeUniversal*(fname: expr) =
       result.data[i] = fname(m.data[i])
 
   proc fname*(m: DMatrix32): DMatrix32 =
-    result.data = newSeq[float32](m.len)
-    result.order = m.order
-    result.M = m.M
-    result.N = m.N
+    result = DMatrix32(data: newSeq[float32](m.len), order:m.order, M:m.M, N:m.N)
     for i in 0 .. < (m.len):
       result.data[i] = fname(m.data[i])
 
@@ -58,10 +55,7 @@ template makeUniversal*(fname: expr) =
       result.data[i] = fname(m.data[i])
 
   proc fname*(m: DMatrix64): DMatrix64 =
-    result.data = newSeq[float64](m.len)
-    result.order = m.order
-    result.M = m.M
-    result.N = m.N
+    result = DMatrix64(data: newSeq[float64](m.len), order:m.order, M:m.M, N:m.N)
     for i in 0 .. < (m.len):
       result.data[i] = fname(m.data[i])
 


### PR DESCRIPTION
Using ref object prevents copies of matrices and can increase
performance when dealing with large matrices.